### PR TITLE
reset sweep at init

### DIFF
--- a/driver/source/main.asm
+++ b/driver/source/main.asm
@@ -150,6 +150,10 @@ __init:
 	lda	#15
 	sta	$4015
 	
+	lda	#$08
+	sta	$4001
+	sta	$4005
+	
 	lda	#3<<4
 	sta	$400C
 	lda	#31<<3


### PR DESCRIPTION
I was asked why SuperNSF square channels can't go low in most players (except VirtuaNSF). The problem is just that the sweep unit is muting them because they are never initialized.